### PR TITLE
Disable doclint to fix the build on JDK8

### DIFF
--- a/proto-pom/jar/pom.xml
+++ b/proto-pom/jar/pom.xml
@@ -149,6 +149,7 @@
                                     <breakiterator>true</breakiterator>
                                     <!-- Exclude precompiled JSPs -->
                                     <excludePackageNames>jsp</excludePackageNames>
+                                    <additionalparam>-Xdoclint:none</additionalparam>
                                     <links>
                                         <!-- Has JPA 2.0 API -->
                                         <link>http://docs.oracle.com/javaee/7/api/</link>
@@ -186,6 +187,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                  <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
On JDK8 javadoc linting is enabled by default thus problems
with javdoc formatting in sbe-jrc terminate the build.

The more proper fix is to fix all javadoc formatting issues.
